### PR TITLE
Remove implicit --tlsverify.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ You just need to enable the tls mode as the following:
 
 ```ruby
   task :production => :common do
-    set :tls, true
+    set :tlsverify, true
     # ...
   end
 ```
@@ -232,6 +232,7 @@ You have to set the following keys:
 
 ```ruby
   task :production => :common do
+    set :tlsverify, true #optional
     set :tlscacert, '/usr/local/certs/ca.pem'
     set :tlscert, '/usr/local/certs/ssl.crt'
     set :tlskey, '/usr/local/certs/ssl.key'

--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -146,17 +146,11 @@ module Centurion::DeployDSL
     end
   end
 
-  def tls_paths_available?
-    Centurion::DockerViaCli.tls_keys.all? { |key| fetch(key).present? }
-  end
-
   def build_tls_params
-    return {} unless fetch(:tlsverify)
-    {
-      tls: fetch(:tlsverify || tls_paths_available?),
-      tlscacert: fetch(:tlscacert),
-      tlscert: fetch(:tlscert),
-      tlskey: fetch(:tlskey)
-    }
+    return {}.tap do |params|
+      Centurion::DockerViaCli.tls_keys.each do |key|
+        params[key] = fetch(key) if fetch(key)
+      end
+    end
   end
 end

--- a/lib/centurion/docker_via_cli.rb
+++ b/lib/centurion/docker_via_cli.rb
@@ -29,22 +29,13 @@ class Centurion::DockerViaCli
   private
 
   def self.tls_keys
-    [:tlscacert, :tlscert, :tlskey]
-  end
-
-  def all_tls_path_available?
-    self.class.tls_keys.all? { |key| @tls_args.key?(key) }
+    [:tlsverify, :tlscacert, :tlscert, :tlskey]
   end
 
   def tls_parameters
     return '' if @tls_args.nil? || @tls_args == {}
 
     tls_flags = ''
-
-    # --tlsverify can be set without passing the cacert, cert and key flags
-    if @tls_args[:tls] == true || all_tls_path_available?
-      tls_flags << ' --tlsverify'
-    end
 
     self.class.tls_keys.each do |key|
       tls_flags << " --#{key}=#{@tls_args[key]}" if @tls_args[key]

--- a/spec/docker_via_cli_spec.rb
+++ b/spec/docker_via_cli_spec.rb
@@ -42,14 +42,14 @@ describe Centurion::DockerViaCli do
     end
   end
   context 'with TLS certificates' do
-    let(:tls_args) { { tls: true, tlscacert: '/certs/ca.pem',
+    let(:tls_args) { { tlsverify: true, tlscacert: '/certs/ca.pem',
                        tlscert: '/certs/cert.pem', tlskey: '/certs/key.pem' } }
     let(:docker_via_cli) { Centurion::DockerViaCli.new('host1', 2375,
                                                        docker_path, tls_args) }
     it 'pulls the latest image given its name' do
       expect(docker_via_cli).to receive(:echo).
                                 with('docker -H=tcp://host1:2375 ' \
-                                     '--tlsverify ' \
+                                     '--tlsverify=true ' \
                                      '--tlscacert=/certs/ca.pem ' \
                                      '--tlscert=/certs/cert.pem ' \
                                      '--tlskey=/certs/key.pem pull foo:latest')
@@ -59,7 +59,7 @@ describe Centurion::DockerViaCli do
     it 'pulls an image given its name & tag' do
       expect(docker_via_cli).to receive(:echo).
                                 with('docker -H=tcp://host1:2375 ' \
-                                     '--tlsverify ' \
+                                     '--tlsverify=true ' \
                                      '--tlscacert=/certs/ca.pem ' \
                                      '--tlscert=/certs/cert.pem ' \
                                      '--tlskey=/certs/key.pem pull foo:bar')
@@ -70,7 +70,7 @@ describe Centurion::DockerViaCli do
       id = '12345abcdef'
       expect(docker_via_cli).to receive(:echo).
                                 with('docker -H=tcp://host1:2375 ' \
-                                     '--tlsverify ' \
+                                     '--tlsverify=true ' \
                                      '--tlscacert=/certs/ca.pem ' \
                                      '--tlscert=/certs/cert.pem ' \
                                      "--tlskey=/certs/key.pem logs -f #{id}")
@@ -81,7 +81,7 @@ describe Centurion::DockerViaCli do
       id = '12345abcdef'
       expect(docker_via_cli).to receive(:echo).
                                 with('docker -H=tcp://host1:2375 ' \
-                                     '--tlsverify ' \
+                                     '--tlsverify=true ' \
                                      '--tlscacert=/certs/ca.pem ' \
                                      '--tlscert=/certs/cert.pem ' \
                                      "--tlskey=/certs/key.pem attach #{id}")


### PR DESCRIPTION
Sometimes we may need to disable client validation of certificate (usualy IP SAN problems). So I disable implicit --tlsverify parameter. To enable --tlsverify parameter set :tlsverify option to true value.
