### PR TITLE
Remove implicit tlsverify.

### DIFF
--- a/lib/centurion/docker_via_cli.rb
+++ b/lib/centurion/docker_via_cli.rb
@@ -37,6 +37,10 @@ class Centurion::DockerViaCli
 
     tls_flags = ''
 
+    if @tls_args[:tls] == true
+      tls_flags << ' --tls=true'
+    end
+
     self.class.tls_keys.each do |key|
       tls_flags << " --#{key}=#{@tls_args[key]}" if @tls_args[key]
     end


### PR DESCRIPTION
Sometimes we may need to disable client validation of certificate (usualy IP SAN problems). So I disable implicit --tlsverify parameter. To enable --tlsverify parameter set :tlsverify option to true value.

FIXED.
