### PR TITLE
Remove implicit tlsverify.

### DIFF
--- a/lib/centurion/deploy_dsl.rb
+++ b/lib/centurion/deploy_dsl.rb
@@ -151,6 +151,8 @@ module Centurion::DeployDSL
       Centurion::DockerViaCli.tls_keys.each do |key|
         params[key] = fetch(key) if fetch(key)
       end
+
+      unless params[:tlsverify] || params == {} then params[:tls] = true
     end
   end
 end


### PR DESCRIPTION
Sometimes we may need to disable client validation of certificate (usualy IP SAN problems). So I disable implicit --tlsverify parameter. To enable --tlsverify parameter set :tlsverify option to true value.

FIXED.
